### PR TITLE
Adding Delimiter Option

### DIFF
--- a/src/firehoseStream.js
+++ b/src/firehoseStream.js
@@ -19,11 +19,12 @@ const defaultBuffer = {
 }
 
 class FirehoseStream extends Writable {
-  constructor({ firehose, streamName, region, credentials, httpOptions, objectMode, buffer, partitionKey }) {
+  constructor({ firehose, streamName, region, credentials, httpOptions, objectMode, buffer, partitionKey, delimiter }) {
     super({ objectMode })
 
     this.streamName   = streamName
     this.buffer       = merge(defaultBuffer, buffer)
+    this.delimiter = delimiter || ''
     this.partitionKey = partitionKey || function getPartitionKey() {
       return Date.now().toString()
     }
@@ -56,7 +57,7 @@ class FirehoseStream extends Writable {
 
     const formattedRecords = records.map((record) => {
       // , PartitionKey: partitionKey
-      return { Data: JSON.stringify(record) }
+      return { Data: JSON.stringify(record) + this.delimiter }
     })
 
     operation.attempt(() => {


### PR DESCRIPTION
From http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Firehose.html

> Kinesis Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (\n) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.

Adding options for delimiter.

Many S3 analytics consumers (Athena) use newline (\n) to disambiguate json record logs.
This was needed in my case.

Verified that:

```
var stream = bunyanFirehose.createStream({
            streamName:  'scridly-logs',
            region: 'us-east-1',
            delimiter: "\n", // any string should work
            credentials: ...
})
```

added a `\n` to the end of every record.